### PR TITLE
Add Dropdown component stories

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -9,4 +9,7 @@
   .sbdocs table {
     border: none;
   }
+  ul, li {
+    list-style: none;
+  }
 </style>

--- a/src/component/Atoms/Dropdown/Dropdown.stories.tsx
+++ b/src/component/Atoms/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,182 @@
+import { useRef, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Dropdown } from "./Dropdown";
+import { DropdownButton } from "./DropdownButton";
+import { DropdownList } from "./DropdownList";
+
+const meta: Meta<typeof Dropdown> = {
+  title: "Atoms/Dropdown",
+  component: Dropdown,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    role: {
+      control: "text",
+      description: "WAI-ARIA role（デフォルト: listbox）",
+    },
+    id: {
+      control: "text",
+      description: "ドロップダウンの一意な ID",
+    },
+    ariaLabel: {
+      control: "text",
+      description: "アクセシビリティ用ラベル",
+    },
+    className: {
+      control: "text",
+      description: "追加の CSS クラス",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const items = ["Option A", "Option B", "Option C"];
+
+export const Default: Story = {
+  render: () => {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    const [selected, setSelected] = useState("Option A");
+
+    return (
+      <div className="relative">
+        <DropdownButton
+          ref={buttonRef}
+          className="flex items-center gap-2 px-4 py-2 rounded-sm bg-surface hover:bg-surface-variant transition cursor-pointer"
+          onClick={() => setIsOpen((prev) => !prev)}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          aria-controls="dropdown-default"
+        >
+          {selected}
+        </DropdownButton>
+        {isOpen && (
+          <Dropdown
+            id="dropdown-default"
+            className="absolute left-0 top-full mt-1 p-1 rounded-lg bg-surface elevation-1 w-[max-content] z-10"
+            buttonRef={buttonRef}
+            closeHandler={() => setIsOpen(false)}
+            ariaLabel="オプション選択"
+          >
+            {items.map((item) => (
+              <DropdownList key={item}>
+                <button
+                  className="flex w-full px-4 py-2 text-left rounded-sm hover:bg-surface-variant cursor-pointer"
+                  onClick={() => {
+                    setSelected(item);
+                    setIsOpen(false);
+                    buttonRef.current?.focus();
+                  }}
+                  tabIndex={0}
+                >
+                  {item}
+                </button>
+              </DropdownList>
+            ))}
+          </Dropdown>
+        )}
+      </div>
+    );
+  },
+};
+
+export const WithManyItems: Story = {
+  render: () => {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    const [selected, setSelected] = useState("Item 1");
+    const manyItems = Array.from({ length: 8 }, (_, i) => `Item ${i + 1}`);
+
+    return (
+      <div className="relative inline-block">
+        <DropdownButton
+          ref={buttonRef}
+          className="flex items-center gap-2 px-4 py-2 rounded-sm bg-surface hover:bg-surface-variant transition cursor-pointer"
+          onClick={() => setIsOpen((prev) => !prev)}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          aria-controls="dropdown-many"
+        >
+          {selected}
+        </DropdownButton>
+        {isOpen && (
+          <Dropdown
+            id="dropdown-many"
+            className="absolute left-0 top-full mt-1 p-1 rounded-lg bg-surface elevation-1 w-[max-content] max-h-48 overflow-y-auto z-10"
+            buttonRef={buttonRef}
+            closeHandler={() => setIsOpen(false)}
+            ariaLabel="アイテム選択"
+          >
+            {manyItems.map((item) => (
+              <DropdownList key={item}>
+                <button
+                  className="flex w-full px-4 py-2 text-left rounded-sm hover:bg-surface-variant cursor-pointer"
+                  onClick={() => {
+                    setSelected(item);
+                    setIsOpen(false);
+                    buttonRef.current?.focus();
+                  }}
+                  tabIndex={0}
+                >
+                  {item}
+                </button>
+              </DropdownList>
+            ))}
+          </Dropdown>
+        )}
+      </div>
+    );
+  },
+};
+
+export const MenuRole: Story = {
+  render: () => {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    const menuItems = ["編集", "複製", "削除"];
+
+    return (
+      <div className="relative">
+        <DropdownButton
+          ref={buttonRef}
+          className="flex items-center gap-2 px-4 py-2 rounded-sm bg-surface hover:bg-surface-variant transition cursor-pointer"
+          onClick={() => setIsOpen((prev) => !prev)}
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
+          aria-controls="dropdown-menu"
+        >
+          メニュー
+        </DropdownButton>
+        {isOpen && (
+          <Dropdown
+            id="dropdown-menu"
+            className="absolute left-0 top-full mt-1 p-1 rounded-lg bg-surface elevation-1 w-[max-content] z-10"
+            buttonRef={buttonRef}
+            closeHandler={() => setIsOpen(false)}
+            role="menu"
+            ariaLabel="アクションメニュー"
+          >
+            {menuItems.map((item) => (
+              <DropdownList key={item} role="menuitem">
+                <button
+                  className="flex w-full px-4 py-2 text-left rounded-sm hover:bg-surface-variant cursor-pointer"
+                  onClick={() => {
+                    setIsOpen(false);
+                    buttonRef.current?.focus();
+                  }}
+                  tabIndex={0}
+                >
+                  {item}
+                </button>
+              </DropdownList>
+            ))}
+          </Dropdown>
+        )}
+      </div>
+    );
+  },
+};

--- a/src/component/Molecules/Pagination/Pagination.stories.tsx
+++ b/src/component/Molecules/Pagination/Pagination.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Pagination } from "./Pagenation";
+
+const meta: Meta<typeof Pagination> = {
+  title: "Molecules/Pagination",
+  component: Pagination,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    totalPage: {
+      control: "number",
+      description: "総ページ数",
+    },
+    currentPage: {
+      control: "number",
+      description: "現在のページ番号",
+    },
+    href: {
+      control: "text",
+      description: "ページネーションのベースURL",
+    },
+    className: {
+      control: "text",
+      description: "追加のCSSクラス",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FirstPage: Story = {
+  args: {
+    totalPage: 10,
+    currentPage: 1,
+    href: "/posts",
+  },
+};
+
+export const MiddlePage: Story = {
+  args: {
+    totalPage: 10,
+    currentPage: 5,
+    href: "/posts",
+  },
+};
+
+export const LastPage: Story = {
+  args: {
+    totalPage: 10,
+    currentPage: 10,
+    href: "/posts",
+  },
+};
+
+export const FewPages: Story = {
+  args: {
+    totalPage: 3,
+    currentPage: 2,
+    href: "/posts",
+  },
+};
+
+export const SinglePage: Story = {
+  args: {
+    totalPage: 1,
+    currentPage: 1,
+    href: "/posts",
+  },
+};

--- a/src/component/Molecules/PostArticleList/PostArticleList.stories.tsx
+++ b/src/component/Molecules/PostArticleList/PostArticleList.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PostArticleList } from "./PostArticleList";
+
+const meta: Meta<typeof PostArticleList> = {
+  title: "Molecules/PostArticleList",
+  component: PostArticleList,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    items: {
+      control: "object",
+      description: "記事一覧データ",
+    },
+    className: {
+      control: "text",
+      description: "追加のCSSクラス",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      {
+        title: "React 19の新機能まとめ",
+        url: "https://example.com/article-1",
+        likes_count: 42,
+        tags: ["React", "TypeScript"],
+      },
+      {
+        title: "Tailwind CSS 4で変わったこと",
+        url: "https://example.com/article-2",
+        likes_count: 128,
+        tags: ["CSS", "Tailwind", "デザイン"],
+      },
+      {
+        title: "アクセシビリティの基本",
+        url: "https://example.com/article-3",
+        likes_count: 56,
+        tags: ["アクセシビリティ", "HTML"],
+      },
+    ],
+  },
+};
+
+export const Single: Story = {
+  args: {
+    items: [
+      {
+        title: "Viteで始めるモダンフロントエンド開発",
+        url: "https://example.com/article-1",
+        likes_count: 200,
+        tags: ["Vite", "JavaScript", "フロントエンド"],
+      },
+    ],
+  },
+};

--- a/src/component/Molecules/ProductCard.tsx/ProductCard.stories.tsx
+++ b/src/component/Molecules/ProductCard.tsx/ProductCard.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ProductCard } from "./ProductCard";
+
+const meta: Meta<typeof ProductCard> = {
+  title: "Molecules/ProductCard",
+  component: ProductCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    title: {
+      control: "text",
+      description: "プロダクト名",
+    },
+    thumbnail: {
+      control: "text",
+      description: "サムネイル画像のURL",
+    },
+    slug: {
+      control: "text",
+      description: "プロダクトのスラグ",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "ポートフォリオサイト",
+    thumbnail: "https://placehold.co/352x198",
+    slug: "portfolio",
+  },
+};

--- a/src/component/Molecules/ProjectCard/ProjectCard.stories.tsx
+++ b/src/component/Molecules/ProjectCard/ProjectCard.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ProjectCard } from "./ProjectCard";
+
+const meta: Meta<typeof ProjectCard> = {
+  title: "Molecules/ProjectCard",
+  component: ProjectCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <ul style={{ listStyle: "none", maxWidth: "400px" }}>
+        <Story />
+      </ul>
+    ),
+  ],
+  argTypes: {
+    project: {
+      control: "object",
+      description: "プロジェクトデータ",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    project: {
+      labels: ["Qiita", "PdM"],
+      title: "Qiita Advent Calendar 2025 プロジェクト",
+      description: "新企画の立案、新機能/機能アップデートの企画/設計を担当した。",
+      term: "2025年8月〜2026年1月",
+      url: "https://example.com/project",
+    },
+  },
+};
+
+export const ManyLabels: Story = {
+  args: {
+    project: {
+      labels: ["Qiita", "Frontend", "Accessibility", "UI"],
+      title: "Qiitaダークモード導入",
+      description: "Qiitaにダークモードを導入するため、カラーパレットの修正、カラートークンの設計、開発を担当した。",
+      term: "2023年2月〜2024年2月",
+      url: "https://example.com/project",
+    },
+  },
+};

--- a/src/component/Molecules/ProjectList/ProjectList.stories.tsx
+++ b/src/component/Molecules/ProjectList/ProjectList.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ProjectList } from "./ProjectList";
+
+const meta: Meta<typeof ProjectList> = {
+  title: "Molecules/ProjectList",
+  component: ProjectList,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    projects: {
+      control: "object",
+      description: "プロジェクト一覧データ",
+    },
+    className: {
+      control: "text",
+      description: "追加のCSSクラス",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    projects: [
+      {
+        labels: ["Qiita", "PdM"],
+        title: "Qiita Advent Calendar 2025 プロジェクト",
+        description: "新企画の立案、新機能/機能アップデートの企画/設計を担当した。",
+        term: "2025年8月〜2026年1月",
+        url: "https://example.com/project-1",
+      },
+      {
+        labels: ["Qiita", "Frontend", "Accessibility", "UI"],
+        title: "Qiitaダークモード導入",
+        description: "Qiitaにダークモードを導入するため、カラーパレットの修正、カラートークンの設計、開発を担当した。",
+        term: "2023年2月〜2024年2月",
+        url: "https://example.com/project-2",
+      },
+      {
+        labels: ["Qiita", "イベント"],
+        title: "Qiita Bash",
+        description: "Qiita Bashに関するイベント企画・集客・運営・配信",
+        term: "2024年4月〜",
+        url: "https://example.com/project-3",
+      },
+      {
+        labels: ["Qiita", "PdM", "UI", "UX"],
+        title: "AIサジェスト機能",
+        description: "機能開発の企画/設計・プロジェクトマネジメント・UXの設計・UIデザインを担当した。",
+        term: "2023年8月〜2023年11月",
+        url: "https://example.com/project-4",
+      },
+    ],
+  },
+};
+
+export const Single: Story = {
+  args: {
+    projects: [
+      {
+        labels: ["Qiita", "Accessibility"],
+        title: "アクセシビリティ改善プロジェクト",
+        description: "アクセシビリティに関する知識の浸透、人材育成、Qiitaのプロダクト改善を担当した。",
+        term: "2024年4月〜",
+        url: "https://example.com/project-1",
+      },
+    ],
+  },
+};

--- a/src/component/Molecules/SkillList/SkillList.stories.tsx
+++ b/src/component/Molecules/SkillList/SkillList.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SkillList } from "./SkillList";
+
+const meta: Meta<typeof SkillList> = {
+  title: "Molecules/SkillList",
+  component: SkillList,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    className: {
+      control: "text",
+      description: "追加のCSSクラス",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/component/Molecules/StageHistoryTable/StageHistoryTable.stories.tsx
+++ b/src/component/Molecules/StageHistoryTable/StageHistoryTable.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StageHistoryTable } from "./StageHistoryTable";
+
+const meta: Meta<typeof StageHistoryTable> = {
+  title: "Molecules/StageHistoryTable",
+  component: StageHistoryTable,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    stageHistories: {
+      control: "object",
+      description: "登壇履歴データの配列",
+    },
+    className: {
+      control: "text",
+      description: "追加のCSSクラス",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    stageHistories: [
+      {
+        date: "2025年8月7日",
+        event: "Canly Tech Hub ~vol.1~ みんなで学ぼう！開発現場におけるMCPの活用事例LT会",
+        eventLink: "https://connpass.com/event/361426/",
+        presentationLink: "https://speakerdeck.com/example",
+      },
+      {
+        date: "2024年9月7日",
+        event: "アクセシビリティカンファレンス名古屋",
+        eventLink: "https://example.com/event-2",
+        presentationLink: "https://speakerdeck.com/example-2",
+      },
+      {
+        date: "2024年5月10日",
+        event: "Meguro.css #10 @ oRo",
+        eventLink: "https://example.com/event-3",
+      },
+    ],
+    className: "w-full",
+  },
+};
+
+export const WithoutPresentationLinks: Story = {
+  args: {
+    stageHistories: [
+      {
+        date: "2023年12月9日",
+        event: "DIST.38 「CSSな夜」",
+        eventLink: "https://example.com/event-1",
+      },
+      {
+        date: "2023年6月2日",
+        event: "DIST.39 「みんなのFigma」",
+        eventLink: "https://example.com/event-2",
+      },
+    ],
+    className: "w-full",
+  },
+};

--- a/src/component/Molecules/StageHistoryTable/StageHistoryTableRow.stories.tsx
+++ b/src/component/Molecules/StageHistoryTable/StageHistoryTableRow.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StageHistoryTableRow } from "./StageHistoryTableRow";
+
+const meta: Meta<typeof StageHistoryTableRow> = {
+  title: "Molecules/StageHistoryTableRow",
+  component: StageHistoryTableRow,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <table>
+        <tbody>
+          <Story />
+        </tbody>
+      </table>
+    ),
+  ],
+  argTypes: {
+    data: {
+      control: "object",
+      description: "登壇履歴データ",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithPresentationLink: Story = {
+  args: {
+    data: {
+      date: "2025年8月7日",
+      event: "Canly Tech Hub ~vol.1~ みんなで学ぼう！開発現場におけるMCPの活用事例LT会",
+      eventLink: "https://connpass.com/event/361426/",
+      presentationLink: "https://speakerdeck.com/example",
+    },
+  },
+};
+
+export const WithoutPresentationLink: Story = {
+  args: {
+    data: {
+      date: "2024年5月10日",
+      event: "Meguro.css #10 @ oRo",
+      eventLink: "https://example.com/event",
+    },
+  },
+};

--- a/src/component/Molecules/TocList/TocList.stories.tsx
+++ b/src/component/Molecules/TocList/TocList.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TocList } from "./TocList";
+
+const meta: Meta<typeof TocList> = {
+  title: "Molecules/TocList",
+  component: TocList,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    items: {
+      control: "object",
+      description: "目次アイテムの配列",
+    },
+    ariaLabelledby: {
+      control: "text",
+      description: "aria-labelledby属性",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      {
+        level: 2,
+        text: "はじめに",
+        id: "introduction",
+      },
+      {
+        level: 2,
+        text: "セットアップ",
+        id: "setup",
+        children: [
+          {
+            level: 3,
+            text: "インストール",
+            id: "installation",
+          },
+          {
+            level: 3,
+            text: "設定",
+            id: "configuration",
+          },
+        ],
+      },
+      {
+        level: 2,
+        text: "使い方",
+        id: "usage",
+      },
+      {
+        level: 2,
+        text: "まとめ",
+        id: "conclusion",
+      },
+    ],
+  },
+};
+
+export const Flat: Story = {
+  args: {
+    items: [
+      { level: 2, text: "概要", id: "overview" },
+      { level: 2, text: "詳細", id: "details" },
+      { level: 2, text: "参考", id: "references" },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- Dropdown コンポーネント（`Dropdown`, `DropdownButton`, `DropdownList`）の Storybook Stories を追加
- Default / WithManyItems / MenuRole の3バリアント
- Storybook の `preview-head.html` にリストスタイルリセットを追加

## Test plan
- [ ] `npm run storybook` で Atoms/Dropdown の各 Story が正しく表示されること
- [ ] Default: ボタンクリックでドロップダウンが開閉し、選択が反映されること
- [ ] WithManyItems: スクロール可能なリストが表示されること
- [ ] MenuRole: `role="menu"` として動作すること
- [ ] ダークモード / ライトモードの両方で表示が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)