### PR TITLE
Add Storybook deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+      - name: Build Storybook
+        run: npm run build-storybook -- -o dist/storybook
       - name: Add SPA 404 fallback
         run: cp dist/index.html dist/404.html
       - name: Setup Pages

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,6 +11,7 @@ const config: StorybookConfig = {
   framework: "@storybook/react-vite",
   viteFinal: async (config) => {
     return mergeConfig(config, {
+      base: "/portfolio/storybook/",
       plugins: [tailwindcss()],
       define: { global: "globalThis" },
       resolve: { alias: { buffer: "buffer" } },


### PR DESCRIPTION
## Summary
- GitHub Actions の deploy ワークフローに Storybook ビルドステップを追加し、`dist/storybook/` に出力
- `.storybook/main.ts` の Vite 設定に `base: "/portfolio/storybook/"` を追加し、GitHub Pages のサブパスでアセットが正しく解決されるように対応

## 公開先
- ポートフォリオ: https://degudegu2510.github.io/portfolio/
- Storybook: https://degudegu2510.github.io/portfolio/storybook/

## Test plan
- [x] `npm run build` でポートフォリオがビルドできることを確認
- [x] `npm run build-storybook -- -o dist/storybook` で Storybook が `dist/storybook/` に出力されることを確認
- [ ] main にマージ後、GitHub Actions が成功し、両URLにアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)