### PR TITLE
Swap display order of Project and Product sections

### DIFF
--- a/src/component/Pages/Home/HomePage.tsx
+++ b/src/component/Pages/Home/HomePage.tsx
@@ -18,8 +18,8 @@ export const HomePage = () => {
     <main className="max-w-6xl px-4 w-full m-auto">
       <FirstView />
       <Profile />
-      <Product />
       <Project />
+      <Product />
       <StageHistory />
       <PostArticle />
     </main>


### PR DESCRIPTION
## Summary
- ホームページの「プロジェクト」と「制作物」セクションの表示順を入れ替え
- 変更前: Profile → 制作物 → プロジェクト → StageHistory → PostArticle
- 変更後: Profile → プロジェクト → 制作物 → StageHistory → PostArticle

## Test plan
- [ ] ホームページで「プロジェクト」が「制作物」より先に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)