### PR TITLE
Add GradientBackground and fix lint errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0..1,-25..0" />
   </head>
   <body>
-    <div id="root" class="bg-grid"></div>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-toc": "^9.0.0",
-        "tailwindcss": "^4.1.10"
+        "tailwindcss": "^4.1.10",
+        "three": "^0.182.0"
       },
       "devDependencies": {
         "@storybook/addon-a11y": "^10.2.7",
@@ -32,6 +33,7 @@
         "@storybook/react-vite": "^10.2.7",
         "@types/react": "19.1.8",
         "@types/react-dom": "19.1.6",
+        "@types/three": "^0.182.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react-swc": "^3.3.2",
@@ -342,6 +344,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -2221,6 +2230,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2394,6 +2410,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/ungap__structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
@@ -2404,6 +2443,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2745,6 +2791,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -3947,6 +4000,13 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -5424,6 +5484,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -7194,6 +7261,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
       "license": "MIT"
     },
     "node_modules/tiny-invariant": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "remark-toc": "^9.0.0",
-    "tailwindcss": "^4.1.10"
+    "tailwindcss": "^4.1.10",
+    "three": "^0.182.0"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^10.2.7",
@@ -36,6 +37,7 @@
     "@storybook/react-vite": "^10.2.7",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
+    "@types/three": "^0.182.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react-swc": "^3.3.2",

--- a/src/component/Atoms/GradientBackground/GradientBackground.stories.tsx
+++ b/src/component/Atoms/GradientBackground/GradientBackground.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { GradientBackground } from "./GradientBackground"
+
+const meta: Meta<typeof GradientBackground> = {
+  title: "Atoms/GradientBackground",
+  component: GradientBackground,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/component/Atoms/GradientBackground/GradientBackground.tsx
+++ b/src/component/Atoms/GradientBackground/GradientBackground.tsx
@@ -121,14 +121,22 @@ const getIsDark = () => {
 
 const getPixelRatio = () => Math.min(window.devicePixelRatio, MAX_PIXEL_RATIO)
 
-export const GradientBackground = () => {
+interface Props {
+  isAnimating?: boolean
+}
+
+export const GradientBackground = ({ isAnimating = true }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null)
+  const isAnimatingRef = useRef(isAnimating)
+
+  useEffect(() => {
+    isAnimatingRef.current = isAnimating
+  }, [isAnimating])
 
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
 
-    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     const colors = getIsDark() ? COLORS.dark : COLORS.light
 
     // Scene
@@ -180,21 +188,38 @@ export const GradientBackground = () => {
     scene.add(flagMesh)
 
     // Animation
-    const clock = new THREE.Clock()
+    let accumulatedTime = 0
+    let lastTime = performance.now()
+    let wasAnimating = isAnimatingRef.current
+    let needsRender = false
     let animationId: number
 
-    if (prefersReducedMotion) {
-      renderer.render(scene, camera)
-    } else {
-      const animate = () => {
-        const elapsedTime = clock.getElapsedTime()
-        backgroundMaterial.uniforms.uTime.value = elapsedTime
-        flagMaterial.uniforms.uTime.value = elapsedTime
+    const animate = () => {
+      const now = performance.now()
+      if (isAnimatingRef.current) {
+        if (!wasAnimating) {
+          lastTime = now
+          wasAnimating = true
+        }
+        accumulatedTime += (now - lastTime) / 1000
+        lastTime = now
+        backgroundMaterial.uniforms.uTime.value = accumulatedTime
+        flagMaterial.uniforms.uTime.value = accumulatedTime
         renderer.render(scene, camera)
-        animationId = requestAnimationFrame(animate)
+      } else {
+        wasAnimating = false
+        lastTime = now
+        if (needsRender) {
+          renderer.render(scene, camera)
+          needsRender = false
+        }
       }
-      animate()
+      animationId = requestAnimationFrame(animate)
     }
+
+    // Initial render
+    renderer.render(scene, camera)
+    animate()
 
     // Resize
     const handleResize = () => {
@@ -202,9 +227,7 @@ export const GradientBackground = () => {
       camera.updateProjectionMatrix()
       renderer.setPixelRatio(getPixelRatio())
       renderer.setSize(window.innerWidth, window.innerHeight)
-      if (prefersReducedMotion) {
-        renderer.render(scene, camera)
-      }
+      needsRender = true
     }
     window.addEventListener("resize", handleResize)
 
@@ -214,9 +237,7 @@ export const GradientBackground = () => {
       backgroundMaterial.uniforms.uTopColor.value.set(c.top)
       backgroundMaterial.uniforms.uMiddleColor.value.set(c.middle)
       backgroundMaterial.uniforms.uBottomColor.value.set(c.bottom)
-      if (prefersReducedMotion) {
-        renderer.render(scene, camera)
-      }
+      needsRender = true
     }
 
     // ModeSelector による colorScheme 変更を検知

--- a/src/component/Atoms/GradientBackground/GradientBackground.tsx
+++ b/src/component/Atoms/GradientBackground/GradientBackground.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useRef } from "react"
+import * as THREE from "three"
+
+const COLORS = {
+  dark: { top: "#787878", middle: "#3c3c3c", bottom: "#000000" },
+  light: { top: "#ffffff", middle: "#f5f5f5", bottom: "#e8e8e8" },
+} as const
+
+const MAX_PIXEL_RATIO = 1.5
+const NOISE_INTENSITY = 30
+const WAVE_SPEED = 0.5
+const WAVE_AMPLITUDE = 0.3
+const FLAG_OPACITY = 8
+
+const backgroundVertexShader = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position.xy, 0.0, 1.0);
+  }
+`
+
+const backgroundFragmentShader = `
+  uniform vec3 uTopColor;
+  uniform vec3 uMiddleColor;
+  uniform vec3 uBottomColor;
+  uniform float uNoiseIntensity;
+  uniform float uTime;
+  varying vec2 vUv;
+
+  float random(vec2 st) {
+    return fract(sin(dot(st.xy, vec2(12.9898,78.233))) * 43758.5453123);
+  }
+
+  void main() {
+    vec3 color;
+    if (vUv.y > 0.5) {
+      float t = (vUv.y - 0.5) * 2.0;
+      color = mix(uMiddleColor, uTopColor, t);
+    } else {
+      float t = vUv.y * 2.0;
+      color = mix(uBottomColor, uMiddleColor, t);
+    }
+    float noise = (random(vUv * 1000.0 + uTime * 0.0001) - 0.5) * uNoiseIntensity / 255.0;
+    color += noise;
+    gl_FragColor = vec4(color, 1.0);
+  }
+`
+
+const flagVertexShader = `
+  uniform float uTime;
+  uniform float uWaveSpeed;
+  uniform float uWaveAmplitude;
+  varying vec2 vUv;
+  varying float vWave;
+
+  vec3 mod289(vec3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+  vec2 mod289(vec2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+  vec3 permute(vec3 x) { return mod289(((x*34.0)+1.0)*x); }
+
+  float snoise(vec2 v) {
+    const vec4 C = vec4(0.211324865405187, 0.366025403784439, -0.577350269189626, 0.024390243902439);
+    vec2 i  = floor(v + dot(v, C.yy));
+    vec2 x0 = v -   i + dot(i, C.xx);
+    vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+    vec4 x12 = x0.xyxy + C.xxzz;
+    x12.xy -= i1;
+    i = mod289(i);
+    vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0)) + i.x + vec3(0.0, i1.x, 1.0));
+    vec3 m = max(0.5 - vec3(dot(x0,x0), dot(x12.xy,x12.xy), dot(x12.zw,x12.zw)), 0.0);
+    m = m*m;
+    m = m*m;
+    vec3 x = 2.0 * fract(p * C.www) - 1.0;
+    vec3 h = abs(x) - 0.5;
+    vec3 ox = floor(x + 0.5);
+    vec3 a0 = x - ox;
+    m *= 1.79284291400159 - 0.85373472095314 * (a0*a0 + h*h);
+    vec3 g;
+    g.x  = a0.x  * x0.x  + h.x  * x0.y;
+    g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+    return 130.0 * dot(m, g);
+  }
+
+  void main() {
+    vUv = uv;
+    vec3 pos = position;
+    float wave1 = snoise(vec2(uv.x * 3.0 - uTime * uWaveSpeed, uv.y * 2.0)) * uWaveAmplitude;
+    float wave2 = snoise(vec2(uv.x * 5.0 - uTime * uWaveSpeed * 1.3, uv.y * 3.0 + uTime * 0.5)) * uWaveAmplitude * 0.5;
+    float wave3 = snoise(vec2(uv.x * 2.0 - uTime * uWaveSpeed * 0.8, uv.y * 4.0 - uTime * 0.3)) * uWaveAmplitude * 0.3;
+    float totalWave = wave1 + wave2 + wave3;
+    pos.z += totalWave * uv.x;
+    pos.y += sin(uv.x * 10.0 - uTime * uWaveSpeed * 2.0) * 0.02 * uv.x;
+    vWave = totalWave;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+  }
+`
+
+const flagFragmentShader = `
+  uniform float uOpacity;
+  uniform float uTime;
+  varying vec2 vUv;
+  varying float vWave;
+
+  void main() {
+    float brightness = 0.3 + vWave * 0.5;
+    float pattern = sin(vUv.x * 20.0 - uTime * 2.0) * 0.05 + 0.5;
+    vec3 color = vec3(brightness + pattern);
+    float alpha = uOpacity / 100.0;
+    alpha *= smoothstep(0.0, 0.1, vUv.x) * smoothstep(1.0, 0.9, vUv.x);
+    alpha *= smoothstep(0.0, 0.1, vUv.y) * smoothstep(1.0, 0.9, vUv.y);
+    gl_FragColor = vec4(color, alpha);
+  }
+`
+
+const getIsDark = () => {
+  const colorScheme = document.documentElement.style.colorScheme
+  if (colorScheme === "dark") return true
+  if (colorScheme === "light") return false
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+}
+
+const getPixelRatio = () => Math.min(window.devicePixelRatio, MAX_PIXEL_RATIO)
+
+export const GradientBackground = () => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const colors = getIsDark() ? COLORS.dark : COLORS.light
+
+    // Scene
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000)
+    camera.position.z = 2
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setSize(window.innerWidth, window.innerHeight)
+    renderer.setPixelRatio(getPixelRatio())
+    container.appendChild(renderer.domElement)
+
+    // Background
+    const backgroundMaterial = new THREE.ShaderMaterial({
+      vertexShader: backgroundVertexShader,
+      fragmentShader: backgroundFragmentShader,
+      uniforms: {
+        uTopColor: { value: new THREE.Color(colors.top) },
+        uMiddleColor: { value: new THREE.Color(colors.middle) },
+        uBottomColor: { value: new THREE.Color(colors.bottom) },
+        uNoiseIntensity: { value: NOISE_INTENSITY },
+        uTime: { value: 0 },
+      },
+      depthTest: false,
+      depthWrite: false,
+    })
+
+    const backgroundGeometry = new THREE.PlaneGeometry(2, 2)
+    const backgroundMesh = new THREE.Mesh(backgroundGeometry, backgroundMaterial)
+    backgroundMesh.position.z = -5
+    scene.add(backgroundMesh)
+
+    // Flag
+    const flagMaterial = new THREE.ShaderMaterial({
+      vertexShader: flagVertexShader,
+      fragmentShader: flagFragmentShader,
+      uniforms: {
+        uTime: { value: 0 },
+        uWaveSpeed: { value: WAVE_SPEED },
+        uWaveAmplitude: { value: WAVE_AMPLITUDE },
+        uOpacity: { value: FLAG_OPACITY },
+      },
+      transparent: true,
+      side: THREE.DoubleSide,
+    })
+
+    const flagGeometry = new THREE.PlaneGeometry(8, 5, 40, 30)
+    const flagMesh = new THREE.Mesh(flagGeometry, flagMaterial)
+    scene.add(flagMesh)
+
+    // Animation
+    const clock = new THREE.Clock()
+    let animationId: number
+
+    if (prefersReducedMotion) {
+      renderer.render(scene, camera)
+    } else {
+      const animate = () => {
+        const elapsedTime = clock.getElapsedTime()
+        backgroundMaterial.uniforms.uTime.value = elapsedTime
+        flagMaterial.uniforms.uTime.value = elapsedTime
+        renderer.render(scene, camera)
+        animationId = requestAnimationFrame(animate)
+      }
+      animate()
+    }
+
+    // Resize
+    const handleResize = () => {
+      camera.aspect = window.innerWidth / window.innerHeight
+      camera.updateProjectionMatrix()
+      renderer.setPixelRatio(getPixelRatio())
+      renderer.setSize(window.innerWidth, window.innerHeight)
+      if (prefersReducedMotion) {
+        renderer.render(scene, camera)
+      }
+    }
+    window.addEventListener("resize", handleResize)
+
+    // Theme change
+    const updateColors = () => {
+      const c = getIsDark() ? COLORS.dark : COLORS.light
+      backgroundMaterial.uniforms.uTopColor.value.set(c.top)
+      backgroundMaterial.uniforms.uMiddleColor.value.set(c.middle)
+      backgroundMaterial.uniforms.uBottomColor.value.set(c.bottom)
+      if (prefersReducedMotion) {
+        renderer.render(scene, camera)
+      }
+    }
+
+    // ModeSelector による colorScheme 変更を検知
+    const observer = new MutationObserver(() => updateColors())
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style"],
+    })
+
+    // auto モード時の OS テーマ変更を検知
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    const handleMediaChange = () => updateColors()
+    mediaQuery.addEventListener("change", handleMediaChange)
+
+    return () => {
+      window.removeEventListener("resize", handleResize)
+      observer.disconnect()
+      mediaQuery.removeEventListener("change", handleMediaChange)
+      cancelAnimationFrame(animationId)
+      backgroundGeometry.dispose()
+      backgroundMaterial.dispose()
+      flagGeometry.dispose()
+      flagMaterial.dispose()
+      renderer.dispose()
+      if (container.firstChild) {
+        container.removeChild(renderer.domElement)
+      }
+    }
+  }, [])
+
+  return (
+    <div ref={containerRef} className="fixed inset-0" aria-hidden="true">
+      <div className="bg-grid absolute inset-0" />
+    </div>
+  )
+}

--- a/src/component/Atoms/MaterialSymbols/MaterialSymbols.tsx
+++ b/src/component/Atoms/MaterialSymbols/MaterialSymbols.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
-interface MaterialSymbolsProps {
+interface MaterialSymbolsProps extends React.HTMLAttributes<HTMLSpanElement> {
   children: string;
   fill?: boolean;
   className?: string;
   size?: 12 | 14 | 16 | 20 | 24 | 28 | 32 | 48;
-  [key: string]: any;
 }
 
 export const MaterialSymbols = ({

--- a/src/component/Molecules/AnimationToggle/AnimationToggle.stories.tsx
+++ b/src/component/Molecules/AnimationToggle/AnimationToggle.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AnimationToggle } from "./AnimationToggle";
+
+const meta: Meta<typeof AnimationToggle> = {
+  title: "Molecules/AnimationToggle",
+  component: AnimationToggle,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playing: Story = {
+  args: {
+    isAnimating: true,
+    onToggle: () => {},
+  },
+};
+
+export const Paused: Story = {
+  args: {
+    isAnimating: false,
+    onToggle: () => {},
+  },
+};

--- a/src/component/Molecules/AnimationToggle/AnimationToggle.tsx
+++ b/src/component/Molecules/AnimationToggle/AnimationToggle.tsx
@@ -1,0 +1,20 @@
+import { MaterialSymbols } from "../../Atoms/MaterialSymbols/MaterialSymbols"
+
+interface Props {
+  isAnimating: boolean
+  onToggle: () => void
+}
+
+export const AnimationToggle = ({ isAnimating, onToggle }: Props) => {
+  return (
+    <button
+      className="flex items-center gap-2 px-4 py-2 rounded-sm hover:bg-surface-variant transition cursor-pointer"
+      onClick={onToggle}
+      aria-pressed={!isAnimating}
+      aria-label={isAnimating ? "アニメーションを一時停止" : "アニメーションを再開"}
+    >
+      <MaterialSymbols>{isAnimating ? "pause" : "play_arrow"}</MaterialSymbols>
+      {isAnimating ? "停止" : "再生"}
+    </button>
+  )
+}

--- a/src/component/Molecules/Pagination/Pagenation.tsx
+++ b/src/component/Molecules/Pagination/Pagenation.tsx
@@ -7,7 +7,7 @@ interface PaginationProps {
   currentPage: number;
   href: string
   className?: string
-};
+}
 
 export const Pagination = ({ totalPage, currentPage, href, className }: PaginationProps) => {
   const [maxVisiblePages, setMaxVisiblePages] = useState(5);

--- a/src/component/Organisms/Header/Header.tsx
+++ b/src/component/Organisms/Header/Header.tsx
@@ -1,20 +1,26 @@
 import { Link } from "react-router"
 import { LogoIcon } from "../../Atoms/BrandIcon"
+import { AnimationToggle } from "../../Molecules/AnimationToggle/AnimationToggle"
 import { ModeSelector } from "../../Molecules/ModeSelector/ModeSelector"
 import { Ref } from "react"
 import { HomePagePath } from "../../../utils/Routes"
 
 interface Props {
   logoRef: Ref<HTMLAnchorElement>
+  isAnimating: boolean
+  onAnimationToggle: () => void
 }
 
-export const Header = ({ logoRef }: Props) => {
+export const Header = ({ logoRef, isAnimating, onAnimationToggle }: Props) => {
   return (
     <header className="flex items-center justify-between max-w-6xl p-4 sticky w-full top-0 m-auto z-10">
       <Link to={HomePagePath()} ref={logoRef}>
         <LogoIcon ariaLabel="ホーム"/>
       </Link>
-      <ModeSelector />
+      <div className="flex items-center">
+        <ModeSelector />
+        <AnimationToggle isAnimating={isAnimating} onToggle={onAnimationToggle} />
+      </div>
     </header>
   )
 }

--- a/src/component/Templates/Base/Base.tsx
+++ b/src/component/Templates/Base/Base.tsx
@@ -2,16 +2,30 @@ import { Outlet, ScrollRestoration } from "react-router";
 import { Header } from "../../Organisms/Header/Header";
 import { Footer } from "../../Organisms/Footer/Footer";
 import { GradientBackground } from "../../Atoms/GradientBackground/GradientBackground";
-import { useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export const Base = () => {
   const LogoRef = useRef<HTMLAnchorElement>(null)
+  const [isAnimating, setIsAnimating] = useState(
+    () => !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  )
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    const handler = (e: MediaQueryListEvent) => setIsAnimating(!e.matches)
+    mediaQuery.addEventListener("change", handler)
+    return () => mediaQuery.removeEventListener("change", handler)
+  }, [])
+
+  const handleAnimationToggle = useCallback(() => {
+    setIsAnimating((prev) => !prev)
+  }, [])
 
   return (
     <>
-      <GradientBackground />
+      <GradientBackground isAnimating={isAnimating} />
       <div className="relative">
-        <Header logoRef={LogoRef}/>
+        <Header logoRef={LogoRef} isAnimating={isAnimating} onAnimationToggle={handleAnimationToggle} />
         <Outlet />
         <Footer logoRef={LogoRef}/>
       </div>

--- a/src/component/Templates/Base/Base.tsx
+++ b/src/component/Templates/Base/Base.tsx
@@ -1,16 +1,20 @@
 import { Outlet, ScrollRestoration } from "react-router";
 import { Header } from "../../Organisms/Header/Header";
 import { Footer } from "../../Organisms/Footer/Footer";
+import { GradientBackground } from "../../Atoms/GradientBackground/GradientBackground";
 import { useRef } from "react";
 
 export const Base = () => {
   const LogoRef = useRef<HTMLAnchorElement>(null)
-  
+
   return (
     <>
-      <Header logoRef={LogoRef}/>
-      <Outlet />
-      <Footer logoRef={LogoRef}/>
+      <GradientBackground />
+      <div className="relative">
+        <Header logoRef={LogoRef}/>
+        <Outlet />
+        <Footer logoRef={LogoRef}/>
+      </div>
       <ScrollRestoration />
     </>
   );

--- a/src/hooks/useArticles.ts
+++ b/src/hooks/useArticles.ts
@@ -1,10 +1,21 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 export interface ArticlesInterface {
   title: string;
   url: string;
   likes_count: number;
   tags: string[];
+}
+
+interface QiitaTag {
+  name: string;
+}
+
+interface QiitaArticle {
+  title: string;
+  url: string;
+  likes_count: number;
+  tags: QiitaTag[];
 }
 
 export interface UseArticlesResult {
@@ -19,7 +30,7 @@ export const useArticles = (page: number = 1, perPage: number = 20): UseArticles
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchArticles = async () => {
+  const fetchArticles = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -32,12 +43,12 @@ export const useArticles = (page: number = 1, perPage: number = 20): UseArticles
         throw new Error('Qiita APIから記事リストの取得に失敗しました');
       }
 
-      const articlesData = await response.json();
-      const formattedArticles = articlesData.map((article: any) => ({
+      const articlesData: QiitaArticle[] = await response.json();
+      const formattedArticles = articlesData.map((article) => ({
         title: article.title,
         url: article.url,
         likes_count: article.likes_count,
-        tags: Array.isArray(article.tags) ? article.tags.map((tag: any) => tag.name) : [],
+        tags: Array.isArray(article.tags) ? article.tags.map((tag) => tag.name) : [],
       }));
 
       setArticles(formattedArticles);
@@ -47,11 +58,11 @@ export const useArticles = (page: number = 1, perPage: number = 20): UseArticles
     } finally {
       setLoading(false);
     }
-  };
+  }, [page, perPage]);
 
   useEffect(() => {
     fetchArticles();
-  }, [page, perPage]);
+  }, [fetchArticles]);
 
   return {
     articles,

--- a/src/hooks/useHead.ts
+++ b/src/hooks/useHead.ts
@@ -19,9 +19,11 @@ const defaultMeta: HeadMeta = {
 
 export const useHead = (meta: Partial<HeadMeta> = {}) => {
   const location = useLocation();
+  const metaStr = JSON.stringify(meta);
 
   useEffect(() => {
-    const mergedMeta = { ...defaultMeta, ...meta };
+    const parsed: Partial<HeadMeta> = JSON.parse(metaStr);
+    const mergedMeta = { ...defaultMeta, ...parsed };
     const currentUrl = `https://degudegu2510.github.io/portfolio${mergedMeta.url}`;
 
     document.title = mergedMeta.title;
@@ -42,7 +44,7 @@ export const useHead = (meta: Partial<HeadMeta> = {}) => {
     updateMetaTag('name', 'twitter:description', mergedMeta.description);
     updateMetaTag('name', 'twitter:image', mergedMeta.ogp);
 
-  }, [location.pathname, JSON.stringify(meta)]);
+  }, [location.pathname, metaStr]);
 };
 
 const updateMetaTag = (attribute: 'name' | 'property', key: string, value?: string) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { Base } from './component/Templates/Base/Base';
 import { Buffer } from 'buffer';
 import * as Routes from './utils/Routes';
 
-(window as any).Buffer = Buffer;
+(window as unknown as Record<string, unknown>).Buffer = Buffer;
 
 const router = createBrowserRouter([
   {

--- a/src/style/reset.css
+++ b/src/style/reset.css
@@ -9,7 +9,7 @@
       Meiryo, sans-serif;
     line-height: var(--line-height-body);
     color: var(--color-high-emphasis);
-    background-color: var(--color-background);
+    background-color: transparent;
   }
 
   #root {


### PR DESCRIPTION
## Summary
- Three.js による WebGL グラデーション背景 + 旗ウェーブアニメーション (`GradientBackground`) を追加
- Project / Product セクションの表示順を入れ替え
- 既存の lint エラー (5件) を修正

## Changes
### GradientBackground コンポーネント
- `devicePixelRatio` を 1.5 に制限しパフォーマンスを最適化
- `prefers-reduced-motion` 対応（アニメーション軽減時は静的描画のみ）
- Geometry / Material の適切な `dispose` によるメモリリーク防止
- PlaneGeometry セグメント数を最適化 (80x60 → 40x30)
- resize 時の `pixelRatio` 再設定
- ダーク/ライトモード自動切り替え対応
- Storybook Stories を追加

### Lint 修正
- `MaterialSymbols`: `any` 型を `React.HTMLAttributes` に置換
- `Pagenation`: 不要なセミコロンを削除
- `main.tsx`: `window as any` を型安全な記述に変更
- `useArticles`: Qiita API レスポンス用の型を定義、`useCallback` で依存配列を修正
- `useHead`: `JSON.stringify` を変数に抽出し依存配列を静的化

## Test plan
- [ ] 開発サーバーでグラデーション背景が表示されることを確認
- [ ] ダーク/ライトモード切り替えで背景色が変わることを確認
- [ ] ブラウザの `prefers-reduced-motion: reduce` 設定でアニメーションが停止することを確認
- [ ] Storybook で GradientBackground の Stories が表示されることを確認
- [ ] `npm run build` が成功することを確認
- [ ] `npm run lint` がエラー 0 であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)