### PR TITLE
Add profile page

### DIFF
--- a/src/component/Pages/Profile/ProfilePage.tsx
+++ b/src/component/Pages/Profile/ProfilePage.tsx
@@ -1,0 +1,17 @@
+import { Profile } from "../../Organisms/Home/Profile"
+import { useHead } from "../../../hooks/useHead"
+import { ProfilePagePath } from "../../../utils/Routes"
+
+export const ProfilePage = () => {
+  useHead({
+    title: 'プロフィール - degudegu2510のポートフォリオ',
+    description: 'degudegu2510のプロフィールページです。スキルや経歴をご覧いただけます。',
+    url: ProfilePagePath(),
+  });
+
+  return (
+    <main className="max-w-6xl px-4 w-full m-auto">
+      <Profile />
+    </main>
+  )
+}

--- a/src/component/Pages/index.tsx
+++ b/src/component/Pages/index.tsx
@@ -3,3 +3,4 @@ export { ProductPage } from "./Product/ProductPage";
 export { StageHistoryPage } from "./StageHistory/StageHistoryPage";
 export { ArticlesPage } from "./Articles/ArticlesPage";
 export { ProjectsPage } from "./Projects/ProjectsPage";
+export { ProfilePage } from "./Profile/ProfilePage";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from "react-router";
-import { HomePage, ProductPage, ArticlesPage, ProjectsPage, StageHistoryPage } from './component/Pages'
+import { HomePage, ProductPage, ArticlesPage, ProjectsPage, StageHistoryPage, ProfilePage } from './component/Pages'
 import './style/index.css'
 import { Base } from './component/Templates/Base/Base';
 import { Buffer } from 'buffer';
@@ -33,6 +33,10 @@ const router = createBrowserRouter([
       {
         path: Routes.ProjectsPagePath(),
         element: <ProjectsPage />,
+      },
+      {
+        path: Routes.ProfilePagePath(),
+        element: <ProfilePage />,
       },
     ]
   },

--- a/src/utils/Routes.ts
+++ b/src/utils/Routes.ts
@@ -3,3 +3,4 @@ export const ProductPagePath = ( slug: string ) => { return `/product/${slug}` }
 export const StageHistoryPagePath = () => { return '/stage-history' }
 export const ArticlesPagePath = () => { return '/articles' }
 export const ProjectsPagePath = () => { return '/projects' }
+export const ProfilePagePath = () => { return '/profile' }


### PR DESCRIPTION
## Summary
- `/profile` ルートにプロフィールページを追加
- `ProfilePagePath()` パスヘルパーを `Routes.ts` に追加
- 既存の `Profile` organism を再利用し、専用ページとして構成

## Test plan
- [ ] `/portfolio/profile` にアクセスしてプロフィールページが表示されることを確認
- [ ] ホームページのプロフィールセクションに影響がないことを確認
- [ ] ダーク/ライトモード切り替えが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)