### PR TITLE
Track .claude/ config directory in repository

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,2 @@
+settings.local.json
+worktrees/

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+このファイルは、Claude Codeがこのリポジトリで作業する際のガイダンスを提供します。
+
+## 言語
+
+このプロジェクトでは、必ず日本語で回答してください。
+技術用語に関しては、必要に応じて、英語そのまま利用してください。
+
+## コマンド
+
+```bash
+npm run dev      # 開発サーバー起動 (Vite HMR)
+npm run build    # TypeScript コンパイル + Vite ビルド
+npm run lint     # ESLint チェック (ts,tsx ファイル)
+npm run preview  # 本番ビルドのプレビュー
+```
+
+## アーキテクチャ
+
+React 19 + TypeScript + Vite + Tailwind CSS 4 で構築されたポートフォリオサイトです。
+
+### ルーティング
+
+- React Router v7 の `createBrowserRouter` を使用
+- ベースパス: `/portfolio`
+- ルートは `src/utils/Routes.ts` でパスヘルパー関数として定義
+- ルーター設定は `src/main.tsx`
+- `Base` テンプレート (`src/component/Templates/Base/Base.tsx`) が全ページを Header/Footer でラップ
+
+### コンポーネント構造 (Atomic Design)
+
+```
+src/component/
+├── Atoms/          # SVG アイコン、ボタン、基本要素
+├── Molecules/      # Atoms の組み合わせ（カード、リスト）
+├── Organisms/      # ページセクション（FirstView, Header, Footer）
+├── Pages/          # ルートコンポーネント
+└── Templates/      # レイアウトラッパー（Base）
+```
+
+### スタイリング (Tailwind CSS 4)
+
+- エントリ: `src/style/index.css` が全スタイルモジュールをインポート
+- `src/style/theme.css`: `@theme` でデザイントークン定義（カラー、タイポグラフィ、ブレークポイント）
+- `src/style/utility.css`: `@utility` でカスタムユーティリティ定義（例: `body-1`, `heading-1`）
+- `light-dark()` で OS の設定に基づくダーク/ライトモード自動切り替え
+- カスタムユーティリティはクラス名として使用: `className="body-2"`
+
+### コンテンツ (Markdown ベース)
+
+- プロダクトページ: `src/contents/Product/{slug}/{slug}.md`
+- `import.meta.glob` で静的インポート
+- remark/rehype パイプラインで処理（GFM、シンタックスハイライト、スラグ生成）
+- Front matter: `title`, `thumbnail`, `keywords`, `description`
+
+### Storybook
+
+Storybook 10 (`@storybook/react-vite`) でコンポーネントカタログを管理しています。
+
+```bash
+npm run storybook        # 開発サーバー起動 (port 6006)
+npm run build-storybook  # 静的ビルド
+```
+
+#### 設定ファイル
+
+- `.storybook/main.ts`: stories のパス、アドオン (`addon-docs`, `addon-a11y`)、Vite 統合 (Tailwind CSS プラグイン含む)
+- `.storybook/preview.tsx`: グローバル decorator（`MemoryRouter` ラップ、テーマ切り替え）、`src/style/index.css` のインポート
+- `.storybook/preview-head.html`: Material Symbols フォント読み込み、Docs 用スタイル調整
+
+#### Stories の規約
+
+- ファイル配置: コンポーネントと同じディレクトリに `{ComponentName}.stories.tsx` として作成
+- 型: `@storybook/react-vite` から `Meta`, `StoryObj` をインポート
+- `tags: ["autodocs"]` で自動ドキュメント生成を有効化
+- `title`: Atomic Design 階層に合わせる（例: `"Atoms/Dropdown"`, `"Molecules/ModeSelector"`）
+- グローバル decorator で `MemoryRouter` が適用済みのため、個別 Story でのルーター設定は不要
+- テーマ切り替え: ツールバーから Light / Dark / Auto を選択可能
+
+
+### 主要な規約
+
+- SVG アイコンは `Atoms/BrandIcon/` に React コンポーネントとして配置
+- Material Symbolsは `Atoms/MaterialSymbols/` 経由で使用
+- 新規ルート追加: `Routes.ts` にパスヘルパーを追加後、`main.tsx` に登録
+- 新規デザイントークン追加: `theme.css` に追加後、`utility.css` で `@utility` にバインド
+
+## GitHub 運用ルール
+- **ツール:** GitHub操作（接続・起票・閲覧）には必ず `gh` コマンドを使用すること。

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: issue
+description: Plan, implement, verify, and create a PR for a GitHub issue end-to-end
+argument-hint: "[issue-url or issue-number]"
+context: fork
+agent: general-purpose
+---
+
+GitHub Issue `$ARGUMENTS` を **計画 → Worktree 作成 → 実装 → 検証 → PR 作成** まで自律的に完遂してください。
+
+---
+
+## Issue の詳細
+
+!`gh issue view "$ARGUMENTS" --json number,title,body,labels 2>/dev/null`
+
+---
+
+## プロジェクト情報
+
+**利用可能なスクリプト:**
+!`jq -r '.scripts // {} | to_entries[] | "  - \(.key): \(.value)"' package.json 2>/dev/null`
+
+**デフォルトブランチ:**
+!`gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"`
+
+**作業ディレクトリ:**
+!`pwd`
+
+---
+
+## 実行手順
+
+各ステップを順番に実行してください。前のステップが完了してから次へ進むこと。
+
+---
+
+### Step 1: 調査・計画
+
+コードを書く前に必ず実施してください。
+
+1. Issue のタイトルと本文を読み、何を実現するか把握する
+2. CLAUDE.md のプロジェクト規約を確認する
+3. 関連ファイルをコードベースから探し、既存パターンを把握する
+4. 実装方針（変更・新規作成するファイル一覧と理由）をまとめて提示する
+
+---
+
+### Step 2: Worktree の作成
+
+Issue 専用の独立した作業ブランチを作成します。
+
+```bash
+ISSUE_NUM=$(gh issue view "$ARGUMENTS" --json number --jq '.number')
+BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+BRANCH="feature/issue-${ISSUE_NUM}"
+WORKTREE_PATH=".claude/worktrees/issue-${ISSUE_NUM}"
+
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" "$BASE"
+echo "✓ Worktree: $WORKTREE_PATH (branch: $BRANCH, base: $BASE)"
+```
+
+以降の実装・検証・コミット・push はすべてこの WORKTREE_PATH 内で行うこと。
+
+---
+
+### Step 3: 実装
+
+Step 1 の計画に基づき、WORKTREE_PATH 内のファイルを変更・作成します。
+
+- CLAUDE.md の規約に従う
+- 論理的な単位で進める（一度に巨大な変更をしない）
+- 実装が完了したら Step 4 へ
+
+---
+
+### Step 4: 検証
+
+以下をすべて通過するまで修正を繰り返すこと。
+
+```bash
+cd "$WORKTREE_PATH"
+
+# Lint
+npm run lint 2>/dev/null \
+  && echo "✓ lint OK" \
+  || echo "✗ lint FAILED — fix errors and re-run"
+
+# TypeScript（tsc が使える場合）
+npx tsc --noEmit 2>/dev/null \
+  && echo "✓ tsc OK" \
+  || echo "✗ tsc FAILED — fix type errors and re-run"
+
+# テスト（スクリプトが存在する場合のみ）
+npm run test 2>/dev/null \
+  && echo "✓ tests OK" \
+  || echo "(no test script — skip)"
+```
+
+エラーが残っている場合は修正して再実行。すべて通過したら Step 5 へ。
+
+---
+
+### Step 5: コミット
+
+```bash
+cd "$WORKTREE_PATH"
+
+ISSUE_NUM=$(gh issue view "$ARGUMENTS" --json number --jq '.number')
+ISSUE_TITLE=$(gh issue view "$ARGUMENTS" --json title --jq '.title')
+
+git add -A
+git commit -m "feat: ${ISSUE_TITLE} (closes #${ISSUE_NUM})"
+```
+
+---
+
+### Step 6: Push & PR 作成
+
+```bash
+cd "$WORKTREE_PATH"
+
+ISSUE_NUM=$(gh issue view "$ARGUMENTS" --json number --jq '.number')
+ISSUE_TITLE=$(gh issue view "$ARGUMENTS" --json title --jq '.title')
+BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+BRANCH="feature/issue-${ISSUE_NUM}"
+
+git push -u origin "$BRANCH"
+
+gh pr create \
+  --base "$BASE" \
+  --title "${ISSUE_TITLE}" \
+  --body "$(cat <<EOF
+## Summary
+
+Closes #${ISSUE_NUM}
+
+## Changes
+
+$(git log --oneline "${BASE}..HEAD" 2>/dev/null)
+
+## Test plan
+
+- [ ] \`npm run lint\` passes
+- [ ] \`npx tsc --noEmit\` passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+PR の URL を最後に報告してください。

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ dist-ssr
 *.sw?
 
 .cursor/
-.claude/
+# .claude/ は追跡対象（settings.local.json / worktrees/ は .claude/.gitignore で除外）
 .document/
 .vite/
 


### PR DESCRIPTION
## Summary

- `.gitignore` から `.claude/` の除外を解除し、プロジェクト設定をリポジトリで管理できるようにする
- 個人設定ファイルは `.claude/.gitignore` で引き続き除外

## 追跡対象ファイル

| ファイル | 内容 |
|---------|------|
| `.claude/CLAUDE.md` | プロジェクトガイドライン（コマンド・アーキテクチャ・規約） |
| `.claude/skills/issue/SKILL.md` | `/issue` カスタムスキルの定義 |
| `.claude/.gitignore` | ローカル設定の除外ルール |

## 除外ファイル（`.claude/.gitignore` で管理）

- `settings.local.json` — 個人の権限許可リスト
- `worktrees/` — Git Worktree の一時ディレクトリ

## Test plan

- [ ] `.claude/CLAUDE.md` がリポジトリで参照できることを確認
- [ ] `settings.local.json` がコミットに含まれていないことを確認
- [ ] `worktrees/` がコミットに含まれていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)