### PR TITLE
feat: スクロール連動フェードインアニメーションを追加

### DIFF
--- a/src/component/Animations/FadeIn/FadeIn.tsx
+++ b/src/component/Animations/FadeIn/FadeIn.tsx
@@ -1,0 +1,22 @@
+import { useScrollAnimation } from "../../../hooks/useScrollAnimation"
+
+type Props = {
+  as?: keyof HTMLElementTagNameMap
+  children: React.ReactNode
+  className?: string
+  translate?: boolean
+}
+
+export const FadeIn = ({ as: Tag = "div", children, className = "", translate = true }: Props) => {
+  const { ref, isInView } = useScrollAnimation<HTMLElement>()
+  const Component = Tag as React.ElementType
+
+  return (
+    <Component
+      ref={ref}
+      className={`transition-all duration-1000 ease-out ${isInView ? `opacity-100 ${translate ? "translate-y-0" : ""}` : `opacity-0 ${translate ? "translate-y-28" : ""}`} ${className}`}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/src/component/Organisms/Home/FirstView.tsx
+++ b/src/component/Organisms/Home/FirstView.tsx
@@ -1,10 +1,15 @@
 import { QiitaIcon, XIcon } from "../../Atoms/BrandIcon"
 import { Logo } from "../../Atoms/Logo/Logo"
 import { ScrollDown } from "../../Atoms/ScrollDown/ScrollDown"
+import { useScrollAnimation } from "../../../hooks/useScrollAnimation"
 
 export const FirstView = () => {
+  const { ref, isInView } = useScrollAnimation<HTMLElement>()
   return (
-    <section className="grid grid-cols-[minmax(0,_1fr)] grid-rows-[minmax(0,_1fr)_auto] h-[calc(100dvh-5rem)] min-h-137 relative">
+    <section
+      ref={ref}
+      className={`grid grid-cols-[minmax(0,_1fr)] grid-rows-[minmax(0,_1fr)_auto] h-[calc(100dvh-5rem)] min-h-137 relative transition-all duration-1000 ease-out ${isInView ? "opacity-100" : "opacity-0"}`}
+    >
       <div className="grid gap-8 items-center content-center py-4">
         <h1>
           <Logo className="w-full max-w-170 h-auto" ariaLabel="Deguchi Hiroki Portfolio"/>

--- a/src/component/Organisms/Home/PostArticle.tsx
+++ b/src/component/Organisms/Home/PostArticle.tsx
@@ -5,27 +5,28 @@ import { ArticlesPagePath } from "../../../utils/Routes"
 import { useArticles } from "../../../hooks/useArticles"
 import { LoadingSpinner } from "../../Atoms/LoadingSpinner/LoadingSpinner"
 import { ErrorMessage } from "../../Atoms/ErrorMessage/ErrorMessage"
+import { FadeIn } from "../../Animations/FadeIn/FadeIn"
 
 export const PostArticle = () => {
   const ITEM_COUNT = 5
   const { articles, loading, error, refetch } = useArticles(1, ITEM_COUNT)
 
   return (
-    <section className="py-16">
+    <FadeIn as="section" className="py-16">
       <h2 className="heading-1">投稿記事</h2>
-        {loading ? (
-          <LoadingSpinner message="記事を読み込み中..." className="mt-8"/>
-        ) : error ? (
-          <ErrorMessage message={error} onRetry={refetch} showRetryButton={false} className="mt-8" />
-        ) : articles.length > 0 ? (
-          <>
-            <PostArticleList items={articles} className="mt-8"/>
-          </>
-        ) : (
-          <div className={`flex flex-col items-center justify-center gap-4 p-8 backdrop-blur-[2px] backdrop-filter bg-surface-alpha rounded-lg border border-gray-variant mt-8`}>
-            <p>記事がありません</p>
-          </div>
-        )}
+      {loading ? (
+        <LoadingSpinner message="記事を読み込み中..." className="mt-8"/>
+      ) : error ? (
+        <ErrorMessage message={error} onRetry={refetch} showRetryButton={false} className="mt-8" />
+      ) : articles.length > 0 ? (
+        <>
+          <PostArticleList items={articles} className="mt-8"/>
+        </>
+      ) : (
+        <div className={`flex flex-col items-center justify-center gap-4 p-8 backdrop-blur-[2px] backdrop-filter bg-surface-alpha rounded-lg border border-gray-variant mt-8`}>
+          <p>記事がありません</p>
+        </div>
+      )}
       <Link
         to={ArticlesPagePath()}
         className="flex items-center hover:bg-surface p-2 pr-0.5 rounded mt-6 w-fit"
@@ -33,6 +34,6 @@ export const PostArticle = () => {
         もっと見る
         <MaterialSymbols size={24}>chevron_right</MaterialSymbols>
       </Link>
-    </section>
+    </FadeIn>
   )
 }

--- a/src/component/Organisms/Home/Product.tsx
+++ b/src/component/Organisms/Home/Product.tsx
@@ -3,13 +3,14 @@ import { ProductCard } from "../../Molecules/ProductCard.tsx/ProductCard"
 import { useProductList } from "../../../hooks/useProductList"
 import { LoadingSpinner } from "../../Atoms/LoadingSpinner/LoadingSpinner"
 import { ErrorMessage } from "../../Atoms/ErrorMessage/ErrorMessage"
+import { FadeIn } from "../../Animations/FadeIn/FadeIn"
 
 export const Product = () => {
   const id = useId()
   const { products, loading, error } = useProductList()
 
   return (
-    <section className="mt-16 py-16">
+    <FadeIn as="section" className="mt-16 py-16">
       <h2 id={id} className="heading-1">制作物</h2>
       {loading ? (
         <LoadingSpinner message="制作物を読み込み中..." className="mt-8" />
@@ -34,6 +35,6 @@ export const Product = () => {
           <p>制作物がありません</p>
         </div>
       )}
-    </section>
+    </FadeIn>
   )
 }

--- a/src/component/Organisms/Home/Profile.tsx
+++ b/src/component/Organisms/Home/Profile.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import { MaterialSymbols } from "../../Atoms/MaterialSymbols/MaterialSymbols"
 import { SkillList } from "../../Molecules/SkillList/SkillList"
 import { profileVideo } from "./img"
+import { FadeIn } from "../../Animations/FadeIn/FadeIn"
 
 export const Profile = () => {
   const [isPause, setIsPause] = useState(false)
@@ -18,7 +19,7 @@ export const Profile = () => {
   }, [isPause])
 
   return (
-    <section className="mt-16 py-16">
+    <FadeIn as="section" className="mt-16 py-16">
       <h2 className="heading-1">プロフィール</h2>
       <div className="grid grid-cols-[auto_minmax(0,_1fr)] gap-8 mt-6 items-start max-tablet:grid-cols-1">
         <div className="grid grid-cols-[minmax(0,_1fr)] gap-2 justify-items-center w-fit">
@@ -62,7 +63,6 @@ export const Profile = () => {
           <SkillList className="mt-2" />
         </div>
       </div>
-    </section>
+    </FadeIn>
   )
-
 }

--- a/src/component/Organisms/Home/Project.tsx
+++ b/src/component/Organisms/Home/Project.tsx
@@ -3,11 +3,12 @@ import { MaterialSymbols } from "../../Atoms/MaterialSymbols/MaterialSymbols"
 import { ProjectsPagePath } from "../../../utils/Routes"
 import { ProjectList } from "../../Molecules/ProjectList/ProjectList"
 import { Projects } from "../../../contents/Project/Project"
+import { FadeIn } from "../../Animations/FadeIn/FadeIn"
 
 export const Project = () => {
   const projects = Projects.slice(0, 6)
   return (
-    <section className="py-16">
+    <FadeIn as="section" className="py-16">
       <h2 className="heading-1">プロジェクト</h2>
       <ProjectList projects={projects} className="mt-8" />
       <Link
@@ -17,6 +18,6 @@ export const Project = () => {
         もっと見る
         <MaterialSymbols size={24}>chevron_right</MaterialSymbols>
       </Link>
-    </section>
+    </FadeIn>
   )
 }

--- a/src/component/Organisms/Home/StageHistory.tsx
+++ b/src/component/Organisms/Home/StageHistory.tsx
@@ -4,15 +4,16 @@ import { StageHistory as StageHistories } from "../../../contents/StageHistory/S
 import { Link } from "react-router"
 import { MaterialSymbols } from "../../Atoms/MaterialSymbols/MaterialSymbols"
 import { StageHistoryPagePath } from "../../../utils/Routes"
+import { FadeIn } from "../../Animations/FadeIn/FadeIn"
 
 export const StageHistory = () => {
   const id = useId()
   const stageHistories = StageHistories.slice(0, 5)
 
   return (
-    <section className="py-16">
+    <FadeIn as="section" className="py-16">
       <h2 id={id} className="heading-1">登壇歴</h2>
-      <StageHistoryTable 
+      <StageHistoryTable
         className="mt-8"
         aria-labelledby={id}
         stageHistories={stageHistories}
@@ -24,6 +25,6 @@ export const StageHistory = () => {
         もっと見る
         <MaterialSymbols size={24}>chevron_right</MaterialSymbols>
       </Link>
-    </section>
+    </FadeIn>
   )
 }

--- a/src/hooks/useScrollAnimation.ts
+++ b/src/hooks/useScrollAnimation.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react"
+
+export const useScrollAnimation = <T extends HTMLElement = HTMLElement>() => {
+  const ref = useRef<T>(null)
+  const [isInView, setIsInView] = useState(false)
+
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    if (prefersReducedMotion) {
+      setIsInView(true)
+      return
+    }
+
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold: 0, rootMargin: "0px 0px -20% 0px" }
+    )
+
+    observer.observe(element)
+
+    return () => {
+      observer.unobserve(element)
+    }
+  }, [])
+
+  return { ref, isInView }
+}


### PR DESCRIPTION
## Summary

- `useScrollAnimation` Hook を追加（`IntersectionObserver` で初回ビューポート進入を検知、以降は unobserve）
- `Animations/FadeIn` コンポーネントを追加（`as` prop で任意の HTML タグを指定可能）
- ホームページの全セクションにフェードインアニメーションを適用
  - `FirstView`: オパシティのみ（レイアウト都合で Hook 直接使用）
  - その他5セクション: `<FadeIn as="section">` でラップ、オパシティ + 上方向への移動
- `prefers-reduced-motion` に対応（設定有効時はアニメーションをスキップ）

## Animation spec

- duration: 1000ms
- easing: ease-out
- translate: 112px → 0（FirstView は除く）
- trigger: ビューポート下端から 20% 内側に入ったタイミング

## Test plan

- [ ] 各セクションが初回スクロール時にフェードインすること
- [ ] 一度表示されたセクションは再度アニメーションしないこと
- [ ] `prefers-reduced-motion: reduce` の環境でアニメーションがスキップされること
- [ ] ライト / ダークモード両方で表示が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)